### PR TITLE
Add multi-arch image publishing (amd64 + arm64) and make Dockerfile arm64-safe

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,36 +6,7 @@ on:
   push:
 
 jobs:
-  # buildx-arm64:
-  #   runs-on: ubuntu-24.04-arm
-  #   permissions:
-  #     contents: read
-  #     packages: write
-  #   steps:
-  #     -
-  #       name: Checkout
-  #       uses: actions/checkout@v6      
-  #     -
-  #       name: Login to GHCR
-  #       uses: docker/login-action@v3
-  #       with:
-  #         registry: ghcr.io
-  #         username: ${{ github.repository_owner  }}
-  #         password: ${{ secrets.GITHUB_TOKEN }}
-  #     -
-  #       name: Set up Docker Buildx
-  #       id: buildx
-  #       uses: docker/setup-buildx-action@v3
-  #     -
-  #       name: Build and push
-  #       uses: docker/build-push-action@v6
-  #       with:
-  #         context: .
-  #         platforms: linux/arm64
-  #         push: true
-  #         tags: ghcr.io/${{ github.repository_owner }}/dutil:latest
-  
-  buildx-x64:
+  buildx:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -43,14 +14,17 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v6      
+        uses: actions/checkout@v6
       -
         name: Login to GHCR
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner  }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       -
         name: Set up Docker Buildx
         id: buildx
@@ -60,6 +34,6 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ghcr.io/${{ github.repository_owner }}/dutil:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,37 +12,45 @@ RUN apt-get update && apt-get install -y \
     software-properties-common \
 && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Microsoft Stuff
-RUN curl https://packages.microsoft.com/keys/microsoft.asc | tee /etc/apt/trusted.gpg.d/microsoft.asc
-RUN add-apt-repository "$(wget -qO- https://packages.microsoft.com/config/ubuntu/22.04/prod.list)"
-# For:
-# sqlcmd
-
-RUN apt-get update && apt-get install -y \
-    git \
-    snmp \
-    snmp-mibs-downloader \
-    dnsutils \
-    iputils-ping \
-    net-tools \
-    vim \
-    jq \
-    bind9-host \
-    mtr-tiny \
-    openssh-client \
-    postgresql-client \
-    python3 \
-    strace \
-    tmux \
-    nmap \
-    openssh-client \
-    htop \
-    isc-dhcp-client \
-    sqlcmd \
-    tcpdump \
-    sshpass \
-    telnet \
-&& apt-get clean && rm -rf /var/lib/apt/lists/*
+# Install tooling and architecture-specific dependencies.
+RUN set -eux; \
+    arch="$(dpkg --print-architecture)"; \
+    if [ "$arch" = "amd64" ]; then \
+      curl https://packages.microsoft.com/keys/microsoft.asc | tee /etc/apt/trusted.gpg.d/microsoft.asc >/dev/null; \
+      add-apt-repository "$(wget -qO- https://packages.microsoft.com/config/ubuntu/22.04/prod.list)"; \
+      sqlcmd_pkg="sqlcmd"; \
+    else \
+      sqlcmd_pkg=""; \
+      echo "Skipping sqlcmd install on unsupported architecture: $arch"; \
+    fi; \
+    apt-get update; \
+    apt-get install -y \
+      git \
+      snmp \
+      snmp-mibs-downloader \
+      dnsutils \
+      iputils-ping \
+      net-tools \
+      vim \
+      jq \
+      bind9-host \
+      mtr-tiny \
+      openssh-client \
+      postgresql-client \
+      python3 \
+      strace \
+      tmux \
+      nmap \
+      openssh-client \
+      htop \
+      isc-dhcp-client \
+      tcpdump \
+      sshpass \
+      telnet \
+      $sqlcmd_pkg \
+    ; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*
 
 
 # # Unprivileged user setup

--- a/README.md
+++ b/README.md
@@ -17,3 +17,6 @@ kubectl run tmp-shell --restart=Never --rm -i --tty --image ghcr.io/nelsonjchen/
 ```sh
 docker run --rm -i --tty ghcr.io/nelsonjchen/dutil
 ```
+
+
+> Note: `sqlcmd` is only installed on `linux/amd64` builds because Microsoft does not publish that package for all architectures.


### PR DESCRIPTION
### Motivation
- Builds pulled on ARM hosts failed due to missing arm64 manifests and architecture-specific packages. 
- The CI should publish a single multi-platform image manifest so `latest` works on both `linux/amd64` and `linux/arm64`.
- The Dockerfile must avoid installing packages that are not published for all architectures (notably `sqlcmd`).

### Description
- Replaced the separate jobs with a single Buildx job in `.github/workflows/build.yaml` that builds and pushes a multi-platform image for `linux/amd64,linux/arm64` and added QEMU setup so cross-arch builds run on `ubuntu-latest`.
- Made the `Dockerfile` architecture-aware by using `dpkg --print-architecture` and installing `sqlcmd` only on `amd64` while keeping the rest of the utilities on all architectures.
- Added a README note clarifying that `sqlcmd` is only installed on `linux/amd64` builds.

### Testing
- Verified the workflow and Dockerfile changes via local diffs and file inspection; the modified files are `.github/workflows/build.yaml`, `Dockerfile`, and `README.md`.
- Attempted local Docker validation with `docker --version && docker buildx version`, but it failed because the Docker CLI is not available in this environment (command not found).
- Pushing and CI validation must be performed by the remote repository CI; the workflow is configured to validate multi-arch builds on the next push and will run in GitHub Actions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cd5484dac83248e2e4917146d52dd)